### PR TITLE
Expand NR ER WR records posting, refactor Supabase and minor fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from itertools import cycle
-import json
 import os
-from itertools import cycle
 from dotenv import load_dotenv
 import time
 import discord
@@ -51,8 +49,6 @@ boot_time = time.time()
 @bot.event
 async def on_ready():
     print(f"We have logged in as {bot.user}, id: {bot.user.id}")
-    with open("settings.json","r") as f:
-        print(json.load(f))
     print(
         f"Setup time: {round((setup_time-start_time),4)} s,Start time: {round((boot_time-setup_time),4)} s"
     )

--- a/src/Cogs/02_wca/02_competition.py
+++ b/src/Cogs/02_wca/02_competition.py
@@ -1,11 +1,9 @@
 import discord
 from discord.ext import commands
-import requests, json
 
 import src.db as db
 import src.hardstorage as hardstorage
 import src.wca_function as wca_function
-import src.functions as functions
 
 from datetime import datetime as dt
 
@@ -71,7 +69,7 @@ class compCog(commands.Cog, name="comp command"):
         send_msg = await ctx.send(embed=q)
         
         #? forced into this
-        channel = db.load_second_table_idd(4)["data"]["send_channel"]
+        channel = db.load_second_table_idd(5)["data"]["announcer_channel"]
         channel = int(channel)
         if ctx.channel.id == channel:
             await send_msg.add_reaction("🟢")

--- a/src/Cogs/02_wca/04_annoucer.py
+++ b/src/Cogs/02_wca/04_annoucer.py
@@ -1,6 +1,5 @@
 import discord
 from discord.ext import commands
-import requests, json
 
 from discord.ext import tasks
 import asyncio
@@ -41,18 +40,28 @@ class annouceCog(commands.Cog, name="annouce command"):
             
         distanced_comps = wca_function.filter_by_distance(all_comps)
         
-        already_printed_comps = db.load_second_table_idd(3)
+        dedupe_row = db.load_second_table_idd(6)
+        if not isinstance(dedupe_row.get("data"), dict):
+            dedupe_row["data"] = {}
+
+        already_printed_comps = dedupe_row.get("data", {}).get("announcer_dedupe")
+        if not isinstance(already_printed_comps, list):
+            already_printed_comps = []
+            dedupe_row["data"]["announcer_dedupe"] = already_printed_comps
         
-        channel = db.load_second_table_idd(4)["data"]["send_channel"]
+        channel = db.load_second_table_idd(5)["data"]["announcer_channel"]
         channel = int(channel)
         ch = self.bot.get_channel(channel)
+        if ch is None:
+            print(f"[ERROR] announcer_channel not found: {channel}")
+            return
         
         final_comps = []
         
         for comp in distanced_comps:
             comp_id = comp["id"]
             
-            if not comp_id in already_printed_comps["data"]["comps"]:
+            if not comp_id in already_printed_comps:
                 final_comps.append(comp)
                 
         
@@ -118,11 +127,11 @@ class annouceCog(commands.Cog, name="annouce command"):
         
         
         for comp_id in send:
-            if not comp_id in already_printed_comps["data"]["comps"]:
-                already_printed_comps["data"]["comps"].append(comp_id)
+            if not comp_id in already_printed_comps:
+                already_printed_comps.append(comp_id)
                 
         
-        db.save_second_table_idd(already_printed_comps)
+        db.save_second_table_idd(dedupe_row)
     
     @check.before_loop
     async def before_send_message(self):

--- a/src/Cogs/02_wca/07_userFinder.py
+++ b/src/Cogs/02_wca/07_userFinder.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands, tasks
-import requests, json
+import requests
 
 from datetime import datetime as dt
 import datetime
@@ -16,14 +16,27 @@ import src.wca_function as wca_function
 COMP_URL = "https://www.worldcubeassociation.org/competitions/{}"
 REGISTERED_URL = "https://www.worldcubeassociation.org/api/v1/competitions/{}/registrations"
 NUMBER_OF_DAYS_TO_SEARCH = 7
-CHANNEL_ANNOUCE = "957586553536921620"
 URL_FOR_REGIONS = "https://www.worldcubeassociation.org/api/v0/countries"
 
-raw_regions = requests.get(URL_FOR_REGIONS).json()
-if isinstance(raw_regions, dict):
-    raw_regions = raw_regions.get("items", [])
-if not isinstance(raw_regions, list):
-    raw_regions = []
+def _load_regions():
+    try:
+        resp = requests.get(URL_FOR_REGIONS, timeout=8)
+        resp.raise_for_status()
+        raw_regions = resp.json()
+        if isinstance(raw_regions, dict):
+            raw_regions = raw_regions.get("items", [])
+        if isinstance(raw_regions, list):
+            return raw_regions
+    except requests.RequestException as exc:
+        print(f"[WARN] regions fetch failed: {exc}; using local country fallback")
+
+    fallback = []
+    for iso2, name in getattr(wca_function, "COUNTRIES_DICT", {}).items():
+        if isinstance(iso2, str) and isinstance(name, str):
+            fallback.append({"iso2": iso2, "name": name})
+    return fallback
+
+raw_regions = _load_regions()
 
 REGIONS = []
 ISO2 = []
@@ -67,67 +80,135 @@ def valid_time(time):
 class userfinderCog(commands.Cog, name="userfinder command"):
     def __init__(self, bot: commands.bot):
         self.bot = bot
-        '''
-        self.userf.start()
-    
-     
-        
-    @tasks.loop(seconds=58*60)
-    async def userf(self):
-        if dt.now().weekday == 2 and dt.now().hour == 8: 
-            print("Sending")
-            
-            start_date = dt.now()        
-            end_date = start_date + timedelta(days=NUMBER_OF_DAYS_TO_SEARCH)  
-            all_competitions = wca_function.list_of_events_from(start_date, end_date)
-            
-            print(len(all_competitions),all_competitions)
-            
-            q = discord.Embed(title=f"Iskalec tekmovanj")
-            q.add_field(name="Časovno območje",
-                        value=f"<t:{int(start_date.timestamp())}:D> - <t:{int(end_date.timestamp())}:D>")
-            
-            
-            ch = self.bot.get_channel(957586553536921620)
-            
-            first_send = await ch.send(embed=q)
-            attending = ""
-            
-            s_time = time.time()
-            for comp in all_competitions:
-                c = wca_function.competitors_in_comp(comp,"slovenia".lower())
-                if c > 0:
-                    print(comp)
-                    
-                    if c == 1:
-                        apnd = f"{c} tekmovalec"
-                    elif c == 2:
-                        apnd = f"{c} tekmovalca"
-                    elif c in [3,4]:
-                        apnd = f"{c} tekmovalci"
-                    else:
-                        apnd = f"{c} tekmovalcev"
-                    
-                    good,comp_data = wca_function.get_comp_data(comp)
-                    
-                    name = comp_data["name"]
-                        
-                    attending += f"[{name}](https://www.worldcubeassociation.org/competitions/{comp}/registrations)\n* {apnd}\n"
-            e_time = time.time()
-            if attending == "":
-                attending = "/"
-            
-            q.add_field(name=f"Tekmovanja v izbranem obdobju, kjer so prijavljeni tekmovalci regije: {'slovenia'.title()}",value=attending,inline=False)
-            q.add_field(name="Statistika",value=f"Skenirano: {len(all_competitions)} tekmovanj. Čas: {int(e_time-s_time)} sec")
-            
-            await first_send.edit(embed=q)
-            
-            await asyncio.sleep(10*60)
+        self._last_weekly_run = None
+        self.weekly_userfinder.start()
 
-    @userf.before_loop
-    async def before_send_message(self):
-        await self.bot.wait_until_ready() 
-    '''
+    async def _build_userfinder_sections(self, nat, start_date, end_date):
+        all_competitions = wca_function.list_of_events_from(start_date, end_date)
+        print(len(all_competitions), all_competitions)
+
+        s_time = time.time()
+        atLeastOneComp = False
+        fetch_failures = 0
+        send_obj = []
+        send_single = ""
+
+        for competition_id in all_competitions:
+            print("trying:", competition_id, end=" ")
+
+            resp = None
+            for _ in range(4):
+                try:
+                    resp = await asyncio.to_thread(
+                        requests.get,
+                        REGISTERED_URL.format(competition_id),
+                        timeout=4,
+                    )
+                    print("trying ", resp.status_code)
+                    if resp.status_code == 200:
+                        break
+                except requests.RequestException:
+                    print("req timeout", competition_id)
+                    resp = None
+
+            if resp is None or resp.status_code != 200:
+                fetch_failures += 1
+                continue
+
+            print(resp.status_code)
+            try:
+                resp = resp.json()
+            except ValueError:
+                fetch_failures += 1
+                continue
+
+            matching_competitors = 0
+            for user in resp:
+                iso2_code = user["user"]["country_iso2"]
+                if iso2_code.lower() == nat.lower():
+                    matching_competitors += 1
+
+            if matching_competitors > 0:
+                atLeastOneComp = True
+                success, comp_data = await asyncio.to_thread(wca_function.get_comp_data, competition_id)
+                competition_name = competition_id
+                if success:
+                    competition_name = comp_data.get("name", competition_id)
+
+                if matching_competitors == 1:
+                    plural = "tekmovalec"
+                elif matching_competitors == 2:
+                    plural = "tekmovalca"
+                elif matching_competitors in [3, 4]:
+                    plural = "tekmovalci"
+                else:
+                    plural = "tekmovalcev"
+
+                to_add = f"* [{competition_name}]({COMP_URL.format(competition_id)})\n  • {matching_competitors} {plural}\n"
+                if len(send_single) + len(to_add) > 1024:
+                    send_obj.append(send_single)
+                    send_single = to_add
+                else:
+                    send_single += to_add
+
+        if send_single != "":
+            send_obj.append(send_single)
+        if not atLeastOneComp:
+            send_obj = ["Ni rezultatov."]
+
+        elapsed = int(round(time.time() - s_time))
+        return all_competitions, send_obj, elapsed
+
+    @tasks.loop(time=datetime.time(hour=16, minute=0, tzinfo=datetime.timezone.utc))
+    async def weekly_userfinder(self):
+        now_utc = datetime.datetime.now(datetime.timezone.utc)
+        if now_utc.weekday() != 2:  # Wednesday
+            return
+
+        run_key = (now_utc.year, now_utc.isocalendar().week)
+        if self._last_weekly_run == run_key:
+            return
+
+        start_date = dt.now()
+        end_date = start_date + timedelta(days=NUMBER_OF_DAYS_TO_SEARCH)
+
+        channel = db.load_second_table_idd(7)["data"]["userfinder_channel"]
+        channel = int(channel)
+        ch = self.bot.get_channel(channel)
+        if ch is None:
+            return
+
+        q = discord.Embed(title="Iskalec tekmovanj")
+        q.add_field(
+            name="Obdobje",
+            value=f"<t:{int(start_date.timestamp())}:D> - <t:{int(end_date.timestamp())}:D>",
+        )
+        first_send = await ch.send(embed=q)
+
+        all_competitions, send_obj, elapsed = await self._build_userfinder_sections("si", start_date, end_date)
+
+        q.add_field(
+            name="Tekmovanja, kjer so prijavljeni tekmovalci regije: Si - Slovenia",
+            value=send_obj[0],
+            inline=False,
+        )
+        q.add_field(
+            name="Statistika",
+            value=f"Skenirano: {len(all_competitions)} tekmovanj. Čas: {elapsed} sec",
+        )
+        await first_send.edit(embed=q)
+
+        if len(send_obj) > 1:
+            for i in range(1, len(send_obj)):
+                q = discord.Embed(title=f"{i+1}. del")
+                q.add_field(name=".", value=send_obj[i])
+                await ch.send(embed=q)
+
+        self._last_weekly_run = run_key
+
+    @weekly_userfinder.before_loop
+    async def before_weekly_userfinder(self):
+        await self.bot.wait_until_ready()
     async def get_regions(ctx: discord.AutocompleteContext):
         return REGIONS        
     
@@ -163,10 +244,8 @@ class userfinderCog(commands.Cog, name="userfinder command"):
             end_date = start_date + timedelta(days=NUMBER_OF_DAYS_TO_SEARCH)
         else:
             end_date = dt.strptime(end_date, '%Y-%m-%d')
-            
-        all_competitions = wca_function.list_of_events_from(start_date, end_date)
-        
-        print(len(all_competitions),all_competitions)
+
+        all_competitions, send_obj, elapsed = await self._build_userfinder_sections(nat, start_date, end_date)
         
         q = discord.Embed(title=f"Iskalec tekmovanj")
         q.add_field(name="Obdobje",
@@ -174,94 +253,11 @@ class userfinderCog(commands.Cog, name="userfinder command"):
         
         first_send = await ctx.send(embed=q)
 
-        s_time = time.time()
-        
-        atLeastOneComp = False
-        fetch_failures = 0
-        
-        
-        send_obj = []
-        send_single = ""
-        
-        for competition_id in all_competitions:
-            print("trying:",competition_id,end=" ")
-
-            resp = None
-            for _ in range(4):
-                try:
-                    resp = await asyncio.to_thread(
-                        requests.get,
-                        REGISTERED_URL.format(competition_id),
-                        timeout=4,
-                    )
-                    print("trying ",resp.status_code)
-                    if resp.status_code == 200:
-                        break
-                except requests.RequestException:
-                    print("req timeout",competition_id)
-                    resp = None
-                
-            if resp is None or resp.status_code != 200:
-                fetch_failures += 1
-                continue
-
-            print(resp.status_code)
-            try:
-                resp = resp.json()
-            except ValueError:
-                fetch_failures += 1
-                continue
-            
-            matching_competitors = 0
-            
-            for user in resp:
-                # {'user': 
-                # {'id': XXX, 'name': 'XXX', 'wca_id': 'XXXXXXXXX', 'gender': 'X', 'country_iso2': 'XX', 
-                # 'country': {'id': 'XXXXXXXX', 'name': 'XXXXXX', 'continentId': '_XXXXXXX', 'iso2': 'XX'}, 'class': 'user'}, 
-                # 'user_id': XXX, 'competing': {'event_ids': ['XXX', 'XXX', 'XXX']}}
-                iso2_code = user["user"]["country_iso2"]
-                
-                if iso2_code.lower() == nat.lower():
-                    matching_competitors += 1
-                    
-                  
-            if matching_competitors > 0:
-                atLeastOneComp = True
-                success, comp_data = await asyncio.to_thread(wca_function.get_comp_data, competition_id)
-                competition_name = competition_id
-                if success:
-                    competition_name = comp_data.get("name", competition_id)
-
-                if matching_competitors == 1:
-                    plural = "tekmovalec"
-                elif matching_competitors == 2:
-                    plural = "tekmovalca"
-                elif matching_competitors in [3, 4]:
-                    plural = "tekmovalci"
-                else:
-                    plural = "tekmovalcev"
-
-                to_add:str = f"* [{competition_name}]({COMP_URL.format(competition_id)})\n  • {matching_competitors} {plural}\n"
-                if (len(send_single) +len(to_add) > 1024):
-                    send_obj.append(send_single)
-                    send_single = to_add
-                else:
-                    send_single += to_add
-                    
-        if (send_single != ""):
-            send_obj.append(send_single)
-
-        if not atLeastOneComp:
-            send_obj = ["Ni rezultatov."]
-        
-        e_time = time.time()
-
-        
         q.add_field(name=f"Tekmovanja, kjer so prijavljeni tekmovalci regije: {nationality.title()}",value=send_obj[0],inline=False)
         
         q.add_field(
             name="Statistika",
-            value=f"Skenirano: {len(all_competitions)} tekmovanj. Čas: {int(round(e_time-s_time))} sec"
+            value=f"Skenirano: {len(all_competitions)} tekmovanj. Čas: {elapsed} sec"
         )
         print("ready to send")
         await first_send.edit(embed=q)

--- a/src/Cogs/03_misc/01_nrs.py
+++ b/src/Cogs/03_misc/01_nrs.py
@@ -1,26 +1,48 @@
 import discord
 from discord.ext import commands
-import requests, json
+import requests
 
 from discord.ext import tasks
-import asyncio
 from datetime import datetime as dt
 
 import src.wca_function as wca_function
 import src.db as db
-import src.hardstorage as hardstorage
 import src.functions as functions
 
-FILE_PATH = "settings.json"
+# Static WCA Europe ISO2 list (sourced from /api/v0/countries on 2026-03-17).
+EUROPEAN_ISO2 = {
+    "AD","AL","AM","AT","AZ","BA","BE","BG","BY","CH","CY","CZ","DE","DK","EE","ES","FI","FR","GB","GE","GR","HR","HU","IE","IL","IS","IT","LI","LT","LU","LV","MC","MD","ME","MK","MT","NL","NO","PL","PT","RO","RS","RU","SE","SI","SK","SM","TR","UA","VA","XE","XK",
+}
+MEAN_EVENT_IDS = {"444bf", "555bf", "333fm", "666", "777"}
 
-def get_channel(channel_type):
-    with open(FILE_PATH) as f:
-        data = json.load(f)
+def should_post_record(record):
+    tag = str(record.get("tag", "")).upper()
+    person = record.get("result", {}).get("person", {})
+    country_iso2 = str(person.get("country", {}).get("iso2", "")).upper()
+    if country_iso2 == "SI" or tag == "WR":
+        return True
+    if tag == "CR":
+        return country_iso2 in EUROPEAN_ISO2
+    return False
 
-    if channel_type == "nr":
-        return data["records"]["channel"]
-    else:   
-        return -1        
+def display_tag(record):
+    tag = str(record.get("tag", "")).upper()
+    country_iso2 = str(record.get("result", {}).get("person", {}).get("country", {}).get("iso2", "")).upper()
+    if tag == "CR" and country_iso2 in EUROPEAN_ISO2:
+        return "ER"
+    return tag
+
+def display_record_type(record_type, event_id):
+    if record_type == "average" and event_id in MEAN_EVENT_IDS:
+        return "mean"
+    return record_type
+
+def load_nr_row():
+    return db.load_second_table_idd(4)
+
+def get_nr_channel():
+    row = db.load_second_table_idd(3)
+    return int(row["data"]["records_channel"])
 
 def already_sent_nr(nr):
     """
@@ -31,14 +53,19 @@ def already_sent_nr(nr):
         
     """
     print("chekcing nr",nr)
-    with open(FILE_PATH,"r") as f:
-        data = json.load(f)
-    print(nr in data["records"]["sent"])
-    if not (nr in data["records"]["sent"]):
+    row = load_nr_row()
+    if not isinstance(row.get("data"), dict):
+        row["data"] = {}
+    already_sent = row.get("data", {}).get("records_dedupe")
+    if not isinstance(already_sent, list):
+        already_sent = []
+        row["data"]["records_dedupe"] = already_sent
+
+    print(nr in already_sent)
+    if not (nr in already_sent):
         print("ins")
-        data["records"]["sent"].append(nr)
-        with open(FILE_PATH,"w") as f:
-            json.dump(data,f)
+        already_sent.append(nr)
+        db.save_second_table_idd(row)
 
         print(0)
         return 0
@@ -48,12 +75,32 @@ def already_sent_nr(nr):
 class nrCog(commands.Cog, name="nr command"):
     def __init__(self, bot: commands.bot):
         self.bot = bot
+        self._first_startup_check_done = False
         self.wca_live_check.start()
 
 
-    @tasks.loop(seconds=900)
+    @tasks.loop(seconds=300)
     async def wca_live_check(self):
-        print("[INFO] wca live record check")
+        now_utc = dt.utcnow()
+        weekday = now_utc.weekday()  # 0=Mon ... 6=Sun
+        minutes = now_utc.hour * 60 + now_utc.minute
+        # Global weekend coverage:
+        # start: Wed 10:00 UTC (UTC+14 already Thu 00:00)
+        # end:   Mon 12:00 UTC (UTC-12 already Mon 00:00)
+        in_window = (
+            (weekday == 2 and minutes >= 10 * 60)  # Wed >=10:00 UTC
+            or (weekday in {3, 4, 5, 6})          # Thu-Sun UTC
+            or (weekday == 0 and minutes < 12 * 60)  # Mon <12:00 UTC
+        )
+        if not in_window and self._first_startup_check_done:
+            print(f"[INFO] NR loop skipped (outside global Thu-Sun window, utc={now_utc.isoformat(timespec='minutes')})")
+            return
+
+        if not self._first_startup_check_done:
+            print("[INFO] NR startup check: running once regardless of weekend window")
+            self._first_startup_check_done = True
+
+        print("[INFO] wca live record check (SI + WR + ER)")
         resp = requests.post(
             url="https://live.worldcubeassociation.org/api/graphql",
             json={
@@ -100,7 +147,7 @@ class nrCog(commands.Cog, name="nr command"):
         passing = []
         print(len(resp))
         for record in resp:
-            if record["result"]["person"]["country"]["iso2"] == "SI":
+            if should_post_record(record):
                 passing.append(record)
         print(len(passing))
             
@@ -110,19 +157,20 @@ class nrCog(commands.Cog, name="nr command"):
             if not already_sent_nr(record["id"]):
                 print("RECORD FOUND !!!", record)
                 
-                titl = f'{record["tag"]} {record["type"]}'
+                show_tag = display_tag(record)
+                person = record["result"]["person"]
+                round_obj = record["result"]["round"]
+                event_id = round_obj["competitionEvent"]["event"]["id"]
+                shown_type = display_record_type(record["type"], event_id)
+                titl = f"{show_tag} {shown_type}"
                 
-                if record["tag"] == "NR":
+                if show_tag == "NR":
                     q = discord.Embed(title=titl,color=discord.Colour.green())
-                elif record["tag"] == "CR":
+                elif show_tag == "ER":
                     q = discord.Embed(title=titl,color=discord.Colour.yellow())
                 else:
                     q = discord.Embed(title=titl,color=discord.Colour.red())
                     
-                
-                person = record["result"]["person"]
-                round_obj = record["result"]["round"]
-                
                 q.add_field(
                     name=f':flag_{person["country"]["iso2"].lower()}: {person["name"]}', # ( https://www.worldcubeassociation.org/persons/{person["wcaId"]} )',
                     value=f'[{person["wcaId"]}](https://www.worldcubeassociation.org/persons/{person["wcaId"]})', 
@@ -138,19 +186,28 @@ class nrCog(commands.Cog, name="nr command"):
                 for el in record["result"]["attempts"]:
                     times.append(el["result"])
                     
-                event_id = round_obj["competitionEvent"]["event"]["id"]
-                    
-                    
-                top_title = ""
-                if record["type"] == "average":
-                    top_title += "AVERAGE:"
+                if shown_type == "mean":
+                    result_label = "MEAN"
+                elif record["type"] == "average":
+                    result_label = "AVERAGE"
                 else:
-                    top_title += "SINGLE:"
+                    result_label = "SINGLE"
 
-                top_title += f' ```{functions.convert_to_human_frm(record["attemptResult"],event_id)}```'
-                bottom_title = f'SOLVES: `{functions.arry_to_human_frm(times,event_id)}`'
-                
-                q.add_field(name=top_title,value=bottom_title)               
+                result_value = functions.convert_to_human_frm(record["attemptResult"], event_id)
+                solves_value = functions.arry_to_human_frm(times, event_id)
+                event_name = round_obj["competitionEvent"]["event"]["name"]
+                comp_name = round_obj["competitionEvent"]["competition"]["name"]
+                q.set_field_at(
+                    1,
+                    name=event_name,
+                    value=(
+                        f"{comp_name}\n"
+                        f"\n"
+                        f"**{result_label}:** `{result_value}`\n"
+                        f"SOLVES: {solves_value}"
+                    ),
+                    inline=False,
+                )
                     
                 """if record["type"] == "average":  
                                  
@@ -165,19 +222,22 @@ class nrCog(commands.Cog, name="nr command"):
                     )
                 """
                 
-                if record["tag"] == "NR":
+                if show_tag == "NR":
                     q.set_thumbnail(url="https://raw.githubusercontent.com/JackMaddigan/images/main/nr.png")
-                elif record["tag"] == "CR":
+                elif show_tag == "ER":
                     q.set_thumbnail(url="https://raw.githubusercontent.com/JackMaddigan/images/main/cr.png")
-                elif record["tag"] == "WR":
+                elif show_tag == "WR":
                     q.set_thumbnail(url="https://raw.githubusercontent.com/JackMaddigan/images/main/wr.png")
                 else:
-                    print("[ERROR] not nr,cr or wr?")
+                    print("[ERROR] not nr,er or wr?")
                 
         
                 
-                channel = get_channel("nr")
+                channel = get_nr_channel()
                 ch = self.bot.get_channel(channel)
+                if ch is None:
+                    print(f"[ERROR] records_channel not found: {channel}")
+                    continue
                 
                 await ch.send(embed=q)
                 print("sent")


### PR DESCRIPTION
## Summary

Uskladi runtime konfig z Supabase vars vrsticami, odstrani odvisnost od lokalnega settings.json in doda nekaj izboljšav zanesljivosti ter izpisa rekordov.

## Spremembe

- objava SI + WR + ER rekordov
- userfinder teče avtomatsko vsako sredo ob 16h UTC
- Records loop teče na 5m, in le ob vikendih (čet-ned)
- Records: za ustrezne discipline se uporablja mean namesto average
- Rekonfiguracija kanalov in dedupe seznamov

## Hardening

- userfinder stability fallback
- announcer & records added guards
- minor cleanup

## Validacija

Lokalno testirano v staging bot/server okolju: vse bp